### PR TITLE
docs: Add API documentation for product deletion endpoint

### DIFF
--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -75,3 +75,11 @@
   - Bad Request: 400 if request data is invalid
 
 **Note**: All fields except `id` are optional. Only provided fields will be updated.
+
+### Delete Product
+
+- **URL**: `/api/products/{id}`
+- **Method**: `DELETE`
+- **Response**:
+  - Success: 204 No Content
+  - Not Found: 404 if product doesn't exist

--- a/docs/backend-setup.md
+++ b/docs/backend-setup.md
@@ -36,3 +36,4 @@
 - `GET /api/products/{id}`: Get a product by ID
 - `POST /api/products`: Create a new product
 - `PUT /api/products`: Update an existing product
+- `DELETE /api/products/{id}`: Delete a product by ID


### PR DESCRIPTION
# Changes
- Added documentation for DELETE /api/products/{id} endpoint in API docs
- Updated backend setup documentation to include the delete endpoint
- No code changes required as delete functionality already exists in repository

## Documentation Updates
- Added complete request/response documentation for delete endpoint
- Includes status codes (204 for success, 404 for not found)
- Maintains consistent documentation style with other endpoints

## Related
- Uses existing DeleteAsync method from EFTFRepository
- Backend implementation already supports this functionality